### PR TITLE
Fix: force BetterReflection to resolve one class per file

### DIFF
--- a/src/Domain/Pipes/Extractors/ClassExtractor.php
+++ b/src/Domain/Pipes/Extractors/ClassExtractor.php
@@ -29,8 +29,8 @@ class ClassExtractor implements Pipe
             new AutoloadSourceLocator(),
         ]);
         $reflector = new DefaultReflector($sourceLocator);
-        $classes = $reflector->reflectAllClasses();
+        $class = $reflector->reflectAllClasses()[0] ?? null;
 
-        return new Collection($classes);
+        return new Collection($class ? [$class] : []);
     }
 }

--- a/tests/Unit/Formatters/FormatResolverTest.php
+++ b/tests/Unit/Formatters/FormatResolverTest.php
@@ -31,8 +31,8 @@ class FormatResolverTest extends TestCase
     public function formatterDataProvider(): array
     {
         return [
-            'console' => [
-                'formatter' => 'console',
+            'table' => [
+                'formatter' => 'table',
                 'expected' => TableFormatter::class,
             ],
             'github' => [


### PR DESCRIPTION
I can't seem to comprehend why, but BetterReflection is resolving multiple classes for test files, and those duplicated classes crash when calling getName()