### PR TITLE
feat: warning baseline

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage>
-        <include>
-            <directory suffix=".php">src/</directory>
-        </include>
-    </coverage>
-    <testsuites>
-        <testsuite name="Permissions Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <php>
-        <env name="CACHE_DRIVER" value="array"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="Permissions Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="CACHE_DRIVER" value="array"/>
+  </php>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Application/Baseline/BaselineCollection.php
+++ b/src/Application/Baseline/BaselineCollection.php
@@ -88,4 +88,25 @@ class BaselineCollection
     {
         return $this->baseline->toArray();
     }
+
+    /**
+     * Get all baseline rules for a specific file
+     *
+     * @param string $filePath
+     * @return ViolationsCollection
+     */
+    public function getViolationsForFile(string $filePath): ViolationsCollection
+    {
+        return new ViolationsCollection(
+            $this->baseline
+                ->map(fn (array $violations): int => $violations[$filePath] ?? 0)
+                ->filter(fn (int $count) => $count > 0)
+            ->map(fn (int $count, string $identifier): Violation => new Violation(
+                $identifier,
+                new FileMatch($filePath, 0),
+                "Found {$count} occurrences of {$identifier}.",
+            ))
+            ->values()
+        );
+    }
 }

--- a/src/Application/Baseline/BaselineCollection.php
+++ b/src/Application/Baseline/BaselineCollection.php
@@ -104,7 +104,7 @@ class BaselineCollection
             ->map(fn (int $count, string $identifier): Violation => new Violation(
                 $identifier,
                 new FileMatch($filePath, 0),
-                "Found {$count} occurrences of {$identifier}.",
+                "Found {$count} occurrences of this error skipped in the baseline.",
             ))
             ->values()
         );

--- a/src/Application/Console/PhecksBaselineWarningsCommand.php
+++ b/src/Application/Console/PhecksBaselineWarningsCommand.php
@@ -10,6 +10,7 @@ use Juampi92\Phecks\Application\Formatters\FormatResolver;
 use Juampi92\Phecks\Domain\Violations\Violation;
 use Juampi92\Phecks\Domain\Violations\ViolationsCollection;
 use Juampi92\Phecks\Domain\Violations\ViolationSeverity;
+use Juampi92\Phecks\Support\PathNormalizer;
 
 class PhecksBaselineWarningsCommand extends Command
 {
@@ -26,7 +27,8 @@ class PhecksBaselineWarningsCommand extends Command
         $baseline = $baselineLoader->load();
 
         /** @var Collection<array-key, string> $files */
-        $files = collect(Arr::wrap($this->argument('file')));
+        $files = collect(Arr::wrap($this->argument('file')))
+            ->map(fn (string $file): string => PathNormalizer::toRelative($file));
 
         $violations = $files
             ->flatMap(fn (string $file): ViolationsCollection => $baseline->getViolationsForFile($file));

--- a/src/Application/Console/PhecksBaselineWarningsCommand.php
+++ b/src/Application/Console/PhecksBaselineWarningsCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Juampi92\Phecks\Application\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Juampi92\Phecks\Application\Baseline\BaselineLoader;
+use Juampi92\Phecks\Application\Formatters\FormatResolver;
+use Juampi92\Phecks\Domain\Violations\Violation;
+use Juampi92\Phecks\Domain\Violations\ViolationsCollection;
+use Juampi92\Phecks\Domain\Violations\ViolationSeverity;
+
+class PhecksBaselineWarningsCommand extends Command
+{
+    /** @var string */
+    protected $signature = 'phecks:warnings
+                                    {--format=github : Pick a formatter.}
+                                    {file*}';
+
+    /** @var string */
+    protected $description = 'Will display the Baselined warnings inside files.';
+
+    public function handle(BaselineLoader $baselineLoader): int
+    {
+        $baseline = $baselineLoader->load();
+
+        /** @var Collection<array-key, string> $files */
+        $files = collect(Arr::wrap($this->argument('file')));
+
+        $violations = $files
+            ->flatMap(fn (string $file): ViolationsCollection => $baseline->getViolationsForFile($file));
+
+        $violations = new ViolationsCollection(
+            $violations->map(fn (Violation $violation): Violation => $violation->setSeverity(ViolationSeverity::WARNING)),
+        );
+
+        $formatter = FormatResolver::resolve($this->option('format'), $this->input, $this->getOutput());
+        $formatter->format($violations);
+
+        // This command doesn't fail.
+        return self::SUCCESS;
+    }
+}

--- a/src/Application/Console/PhecksBaselineWarningsCommand.php
+++ b/src/Application/Console/PhecksBaselineWarningsCommand.php
@@ -19,7 +19,7 @@ class PhecksBaselineWarningsCommand extends Command
                                     {file*}';
 
     /** @var string */
-    protected $description = 'Will display the Baselined warnings inside files.';
+    protected $description = 'Will display the baselined error inside files as warnings.';
 
     public function handle(BaselineLoader $baselineLoader): int
     {

--- a/src/Domain/Violations/Violation.php
+++ b/src/Domain/Violations/Violation.php
@@ -75,4 +75,14 @@ class Violation
     {
         return $this->severity;
     }
+
+    /**
+     * @param ViolationSeverity::* $severity
+     */
+    public function setSeverity(string $severity): self
+    {
+        $this->severity = $severity;
+
+        return $this;
+    }
 }

--- a/src/PhecksServiceProvider.php
+++ b/src/PhecksServiceProvider.php
@@ -3,8 +3,7 @@
 namespace Juampi92\Phecks;
 
 use Illuminate\Support\ServiceProvider;
-use Juampi92\Phecks\Application\Console\PheckMakeCommand;
-use Juampi92\Phecks\Application\Console\PhecksRunCommand;
+use Juampi92\Phecks\Application\Console;
 
 class PhecksServiceProvider extends ServiceProvider
 {
@@ -33,8 +32,9 @@ class PhecksServiceProvider extends ServiceProvider
             $this->registerPublishables();
 
             $this->commands([
-                PhecksRunCommand::class,
-                PheckMakeCommand::class,
+                Console\PhecksRunCommand::class,
+                Console\PheckMakeCommand::class,
+                Console\PhecksBaselineWarningsCommand::class,
             ]);
         }
     }

--- a/tests/Feature/PhecksBaselineWarningsTest.php
+++ b/tests/Feature/PhecksBaselineWarningsTest.php
@@ -34,4 +34,13 @@ class PhecksBaselineWarningsTest extends TestCase
         // Assert
         $this->assertEquals(0, $exitCode, 'The command must always return success');
     }
+
+    public function test_should_print_nothing_if_baseline_does_not_exist(): void
+    {
+        // Act
+        $exitCode = $this->artisan('phecks:warnings ./app/ClassA.php ./app/ClassB.php')->run();
+
+        // Assert
+        $this->assertEquals(0, $exitCode, 'The command must always return success');
+    }
 }

--- a/tests/Feature/PhecksBaselineWarningsTest.php
+++ b/tests/Feature/PhecksBaselineWarningsTest.php
@@ -17,7 +17,7 @@ class PhecksBaselineWarningsTest extends TestCase
                 './app/ClassB.php' => 2,
             ],
             'IdentifierBar' => [
-                './app/ClassB.php' => 2,
+                './app/ClassB.php' => 3,
                 './app/ClassC.php' => 9,
             ],
         ];
@@ -29,7 +29,11 @@ class PhecksBaselineWarningsTest extends TestCase
         );
 
         // Act
-        $exitCode = $this->artisan('phecks:warnings ./app/ClassA.php ./app/ClassB.php')->run();
+        $exitCode = $this->artisan('phecks:warnings ./app/ClassA.php app/ClassB.php')
+            ->expectsOutput("::warning file=./app/ClassA.php,line=0,title=IdentifierFoo::Found 1 occurrences of this error skipped in the baseline.")
+            ->expectsOutput("::warning file=./app/ClassB.php,line=0,title=IdentifierFoo::Found 2 occurrences of this error skipped in the baseline.")
+            ->expectsOutput("::warning file=./app/ClassB.php,line=0,title=IdentifierBar::Found 3 occurrences of this error skipped in the baseline.")
+            ->run();
 
         // Assert
         $this->assertEquals(0, $exitCode, 'The command must always return success');

--- a/tests/Feature/PhecksBaselineWarningsTest.php
+++ b/tests/Feature/PhecksBaselineWarningsTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Juampi92\Phecks\Tests\Feature;
+
+use Juampi92\Phecks\Application\Baseline\BaselineCollection;
+use Juampi92\Phecks\Application\Baseline\BaselineLoader;
+use Mockery;
+
+class PhecksBaselineWarningsTest extends TestCase
+{
+    public function test_should_print_warnings_for_baseline(): void
+    {
+        // Arrange
+        $baseline = [
+            'IdentifierFoo' => [
+                './app/ClassA.php' => 1,
+                './app/ClassB.php' => 2,
+            ],
+            'IdentifierBar' => [
+                './app/ClassB.php' => 2,
+                './app/ClassC.php' => 9,
+            ],
+        ];
+        $this->instance(
+            BaselineLoader::class,
+            tap(Mockery::mock(BaselineLoader::class), function ($mock) use ($baseline) {
+                $mock->shouldReceive('load')->andReturn(new BaselineCollection($baseline));
+            }),
+        );
+
+        // Act
+        $exitCode = $this->artisan('phecks:warnings ./app/ClassA.php ./app/ClassB.php')->run();
+
+        // Assert
+        $this->assertEquals(0, $exitCode, 'The command must always return success');
+    }
+}

--- a/tests/Unit/Baseline/BaselineCollectionTest.php
+++ b/tests/Unit/Baseline/BaselineCollectionTest.php
@@ -64,4 +64,25 @@ class BaselineCollectionTest extends TestCase
         $this->assertEquals('./app/B.php', $violationFiles[1]);
         $this->assertEquals('./app/C.php', $violationFiles[2]);
     }
+
+    public function test_should_get_violations_per_file(): void
+    {
+        // Arrange
+        $filePath = './app/A.php';
+
+        $baselineViolations = new ViolationsCollection([
+            new Violation('A', new FileMatch($filePath), 'lorem ipsum'),
+            new Violation('A', new FileMatch('./app/C.php'), 'lorem ipsum'),
+            new Violation('B', new FileMatch($filePath), 'lorem ipsum 2'),
+            new Violation('B', new FileMatch('./app/Z.php'), 'lorem ipsum'),
+        ]);
+
+        // Act
+        $baseline = BaselineCollection::fromViolations($baselineViolations);
+        $fileViolations = $baseline->getViolationsForFile($filePath);
+
+        $this->assertCount(2, $fileViolations);
+        $this->assertEquals('A', $fileViolations[0]->getIdentifier());
+        $this->assertEquals('B', $fileViolations[1]->getIdentifier());
+    }
 }

--- a/tests/Unit/Formatters/FormatResolverTest.php
+++ b/tests/Unit/Formatters/FormatResolverTest.php
@@ -28,7 +28,7 @@ class FormatResolverTest extends TestCase
         $this->assertInstanceOf($expected, $formatter);
     }
 
-    public function formatterDataProvider(): array
+    public static function formatterDataProvider(): array
     {
         return [
             'table' => [

--- a/tests/Unit/Pipes/Extractors/MethodExtractorTest.php
+++ b/tests/Unit/Pipes/Extractors/MethodExtractorTest.php
@@ -60,7 +60,7 @@ class MethodExtractorTest extends TestCase
         );
     }
 
-    public function methodFilterDataProvider(): array
+    public static function methodFilterDataProvider(): array
     {
         return [
             'private' => [

--- a/tests/Unit/Support/PathNormalizerTest.php
+++ b/tests/Unit/Support/PathNormalizerTest.php
@@ -17,7 +17,7 @@ class PathNormalizerTest extends TestCase
         $this->assertEquals(value($expected), PathNormalizer::toAbsolute(value($path)));
     }
 
-    public function toAbsoluteDataProvider(): array
+    public static function toAbsoluteDataProvider(): array
     {
         return [
             'Absolute to Absolute' => [
@@ -39,7 +39,7 @@ class PathNormalizerTest extends TestCase
         $this->assertEquals(value($expected), PathNormalizer::toRelative(value($path)));
     }
 
-    public function toRelativeDataProvider(): array
+    public static function toRelativeDataProvider(): array
     {
         return [
             'absolute to relative' => [


### PR DESCRIPTION
# Description

This PR adds a new command:

`php artisan pheck:warnings {file*} --format=github`

**Given a list of files, it will warn if these files have baselined errors.**

## Purpose

The main motivation for this feature was to run it in CI after a Pull Request, with the list of changed files.

When a developer modifies a file that has ignored errors, they will get a warning, as a sort of invitation to fix it: "now that you're touching this file, why don't you also fix it"?

This feature is completely optional.